### PR TITLE
Parallel compilation

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,11 +21,14 @@ jobs:
       - name: Install Theos
         run: bash -c "$(curl -fsSL https://raw.githubusercontent.com/roothide/theos/master/bin/install-theos)"
 
+      - name: Install make
+        run: brew install make
+
       - name: Setup Environment
         run: echo "THEOS=~/theos" >> $GITHUB_ENV
 
       - name: Make Bootstrap Package
-        run: make package
+        run: gmake -j$(sysctl -n hw.ncpu) package
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Xcode toolchain does not include the latest version of Make. In fact, it includes Make 3.81 from 2006! And parallel building is not supported on this version.
A better solution is GNU `make`. More info [here](https://theos.dev/docs/parallel-building). This PR was inspired by [this Makefile](https://github.com/palera1n/jbinit/blob/b6ebdbd033e3e8d7d78a11c81985c9afebf3aecc/.github/workflows/build.yml#L33) done by palera1n developers.

I tested it using GitHub Actions. It works!