### PR TITLE
Update Localizable.strings: Correction en linea 46

### DIFF
--- a/Bootstrap/es.lproj/Localizable.strings
+++ b/Bootstrap/es.lproj/Localizable.strings
@@ -43,7 +43,7 @@
 "bootstrap not installed" = "bootstrap no esta instalado";
 "system bootstrapped" = "sistema con bootstrap";
 "system not bootstrapped" = "el sistema no tiene bootstrap";
-"bootstrap server check successful" = "el servidor bootstrap fue checkeado exitosamente";
+"bootstrap server check successful" = "el servidor bootstrap fue revisado exitosamente";
 
 "It seems that you have the Filza app installed, which may be detected as jailbroken. You can enable Tweak for it to hide it." = "Parece que tienes la app de Filza instalada, La cual puede ser detectada como Jailbroken. Puedes activar el tweak para ocultarla.";
 


### PR DESCRIPTION
"revisado" is a more accurate Spanish word to use instead"checkeado" in place of the original English word "check".