### PR TITLE
Update Localizable.strings(zh-CN)

### DIFF
--- a/Bootstrap/zh-CN.lproj/Localizable.strings
+++ b/Bootstrap/zh-CN.lproj/Localizable.strings
@@ -58,7 +58,7 @@
 "Reboot Device" = "重启设备";
 "The current bootstrapped version is inconsistent with the Bootstrap app version, and you need to reboot the device to update it." = "当前 BootStrap 环境和 BootStrap 应用程序不一致，请重启设备更新环境";
 
-"Your trollstore version is too old, Bootstrap only supports trollstore>=2.0, you have to update your trollstore then reinstall Bootstrap app." = "你的 TrollStore 版本太低，Bootstrap 仅支持 TrollStore2.0 及以上，请更新 TrollStore 后重新尝试安装 BootStrap";
+"Your trollstore version is too old, Bootstrap only supports trollstore>=2.0, you have to update your trollstore then reinstall Bootstrap app." = "你的 TrollStore 版本太低，BootStrap 需要 TrollStore 2.0 或更高版本，请更新 TrollStore 后再次尝试安装 BootStrap";
 
 "Your device does not seem to have developer mode enabled.\n\nPlease enable developer mode and reboot your device." = "你的设备貌似没有开启开发者模式\n\n请启用开发者模式并重启设备";
 

--- a/Bootstrap/zh-CN.lproj/Localizable.strings
+++ b/Bootstrap/zh-CN.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 "Respring" = "注销";
 "Rebuild Apps" = "重建应用";
 "Rebuild Icon Cache" = "重建图标缓存";
-"Reinstall Sileo & Zebra" = "重装Sileo&Zebra";
+"Reinstall Sileo & Zebra" = "重装 Sileo & Zebra";
 "Uninstall" = "卸载";
 "Credits" = "鸣谢";
 "New Version Available" = "可更新";
@@ -18,56 +18,56 @@
 "OK" = "了解";
 "Error" = "错误";
 "Warning" = "警告";
-"Applying" = "应用中";
+"Applying" = "正在应用";
 "Cancel" = "取消";
 "Update" = "更新环境";
-"Bootstrapping" = "正在BootStrap...";
+"Bootstrapping" = "正在 BootStrap...";
 "Uninstall" = "卸载";
-"Uninstalling" = "正在卸载中...";
-"bootstrap uninstalled" = "成功卸载BootStrap";
+"Uninstalling" = "正在卸载...";
+"bootstrap uninstalled" = "成功卸载 BootStrap";
 
 "Enable Tweak for App" = "启用应用插件";
 "name or identifier" = "应用名称或标识符";
 
 "Server Not Running" = "服务未运行";
 
-"for unknown reasons the bootstrap server is not running, the only thing we can do is to restart it now." = "未知原因导致BootStrap服务未运行, 请重启服务";
+"for unknown reasons the bootstrap server is not running, the only thing we can do is to restart it now." = "未知原因导致 BootStrap 服务未运行，请重启服务";
 
 "Restart Server" = "重启服务";
-"bootstrap server restart successful" = "BootStrap服务重启成功";
+"bootstrap server restart successful" = "BootStrap 服务重启成功";
 
 "Rebuilding" = "重建中...";
-"Don't exit Bootstrap app until show the lock screen" = "出现锁屏界面之前不要退出BootStrap";
+"Don't exit Bootstrap app until show the lock screen" = "请在出现锁屏界面之前不要退出 BootStrap";
 
-"bootstrap installed" = "已安装BootStrap";
-"bootstrap not installed" = "未安装BootStrap";
+"bootstrap installed" = "已安装 BootStrap";
+"bootstrap not installed" = "未安装 BootStrap";
 "system bootstrapped" = "系统已引导";
 "system not bootstrapped" = "系统未引导";
-"bootstrap server check successful" = "BootStrap服务检查正常";
+"bootstrap server check successful" = "BootStrap 服务检查正常";
 
-"It seems that you have the Filza app installed, which may be detected as jailbroken. You can enable Tweak for it to hide it." = "看起来你安装了Fliza, 可能会被检测到越狱, 你可以通过启用插件来隐藏它";
+"It seems that you have the Filza app installed, which may be detected as jailbroken. You can enable Tweak for it to hide it." = "看起来你安装了 Fliza，可能会被检测到越狱，你可以通过启用插件来隐藏它";
 
-"Status: Rebuilding Apps" = "状态: 重建应用程序中...";
-"Status: Reinstalling Sileo" = "状态: 重装Sileo中...";
-"Status: Reinstalling Zebra" = "状态: 重装Zebra中...";
-"Sileo and Zebra reinstalled!" = "已重新安装Sileo和Zebra";
+"Status: Rebuilding Apps" = "状态: 正在重建应用程序...";
+"Status: Reinstalling Sileo" = "状态: 正在重装 Sileo...";
+"Status: Reinstalling Zebra" = "状态: 正在重装 Zebra...";
+"Sileo and Zebra reinstalled!" = "已重新安装 Sileo 和 Zebra";
 "Status: Rebuilding Icon Cache" = "状态: 重建图标缓存中...";
 
-"openssh package is not installed" = "OpenSSH未安装";
+"openssh package is not installed" = "OpenSSH 未安装";
 
 "Reboot Device" = "重启设备";
-"The current bootstrapped version is inconsistent with the Bootstrap app version, and you need to reboot the device to update it." = "当前BootStrap环境和BootStrap应用程序不一致, 请重启设备更新环境";
+"The current bootstrapped version is inconsistent with the Bootstrap app version, and you need to reboot the device to update it." = "当前 BootStrap 环境和 BootStrap 应用程序不一致，请重启设备更新环境";
 
-"Your trollstore version is too old, Bootstrap only supports trollstore>=2.0, you have to update your trollstore then reinstall Bootstrap app." = "你的TrollStore版本太低, Bootstrap仅支持TrollStore2.0及以上, 请更新TrollStore后重新尝试安装BootStrap";
+"Your trollstore version is too old, Bootstrap only supports trollstore>=2.0, you have to update your trollstore then reinstall Bootstrap app." = "你的 TrollStore 版本太低，Bootstrap 仅支持 TrollStore2.0 及以上，请更新 TrollStore 后重新尝试安装 BootStrap";
 
 "Your device does not seem to have developer mode enabled.\n\nPlease enable developer mode and reboot your device." = "你的设备貌似没有开启开发者模式\n\n请启用开发者模式并重启设备";
 
-"roothide dopamine has been installed on this device, now install this bootstrap may break it!" = "你已经安装了RootHide版的多巴胺, 现在安装BootStrap可能会破坏已安装的环境";
+"roothide dopamine has been installed on this device, now install this bootstrap may break it!" = "你已经安装了 RootHide 版 Dopamine，现在安装 BootStrap 可能会破坏已安装的环境";
 
-"You have installed an old beta version, please disable all app tweaks and reboot the device to uninstall it so that you can install the new version bootstrap." = "你安装了低版本的测试版, 请在AppEnabler中取消所有应用程序注入, 重启设备, 卸载环境后安装新版本的BootStrap";
+"You have installed an old beta version, please disable all app tweaks and reboot the device to uninstall it so that you can install the new version bootstrap." = "你安装了早期的测试版，请在“应用列表”中关闭所有应用程序注入，重启设备并卸载环境后安装新版本的 BootStrap";
 
-"openssh launch successful" = "OpenSSH启动成功";
-"respring now..." = "注销中...";
+"openssh launch successful" = "OpenSSH 启动成功";
+"respring now..." = "正在注销...";
 
-"Are you sure to uninstall bootstrap?\n\nPlease make sure you have disabled tweak for all apps before uninstalling." = "你确定要卸载BootStrap吗?\n\n卸载之前请确保你已经在AppEnabler中关闭了所有应用注入";
+"Are you sure to uninstall bootstrap?\n\nPlease make sure you have disabled tweak for all apps before uninstalling." = "你确定要卸载 BootStrap 吗？\n\n卸载之前请确保你已经在“应用列表”中关闭了所有应用注入";
 

--- a/Bootstrap/zh-CN.lproj/Localizable.strings
+++ b/Bootstrap/zh-CN.lproj/Localizable.strings
@@ -47,11 +47,11 @@
 
 "It seems that you have the Filza app installed, which may be detected as jailbroken. You can enable Tweak for it to hide it." = "看起来你安装了 Fliza，可能会被检测到越狱，你可以通过启用插件来隐藏它";
 
-"Status: Rebuilding Apps" = "状态: 正在重建应用程序...";
-"Status: Reinstalling Sileo" = "状态: 正在重装 Sileo...";
-"Status: Reinstalling Zebra" = "状态: 正在重装 Zebra...";
+"Status: Rebuilding Apps" = "状态：正在重建应用程序...";
+"Status: Reinstalling Sileo" = "状态：正在重装 Sileo...";
+"Status: Reinstalling Zebra" = "状态：正在重装 Zebra...";
 "Sileo and Zebra reinstalled!" = "已重新安装 Sileo 和 Zebra";
-"Status: Rebuilding Icon Cache" = "状态: 重建图标缓存中...";
+"Status: Rebuilding Icon Cache" = "状态：重建图标缓存中...";
 
 "openssh package is not installed" = "OpenSSH 未安装";
 


### PR DESCRIPTION
1. For the sake of God, please separate Chinese and English characters with spaces.
2. I don't know why English commas and spaces (, ) are used for pauses in Chinese; we should use Chinese commas (，) directly.

1.看在上帝的份上在中文与英文字符之间用空格隔开
2.不知道为什么中文中使用英文的逗号和空格（, ）来停顿，应该直接使用中文逗号（，）